### PR TITLE
Support for Node 4+

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,4 +6,15 @@ node_js:
   - "5"
 script:
   - "npm test"
-before_install: sudo apt-get install libcairo2-dev libjpeg8-dev libpango1.0-dev libgif-dev build-essential g++
+addons:
+  apt:
+    sources:
+      - ubuntu-toolchain-r-test
+    packages:
+      - libcairo2-dev
+      - libjpeg8-dev
+      - libpango1.0-dev
+      - libgif-dev
+      - g++-4.8
+env:
+  - CXX=g++-4.8

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 language: node_js
 node_js:
   - "0.10"
+  - "0.12"
+  - "4.1"
+  - "5"
 script:
   - "npm test"
 before_install: sudo apt-get install libcairo2-dev libjpeg8-dev libpango1.0-dev libgif-dev build-essential g++

--- a/bin/shalam
+++ b/bin/shalam
@@ -2,7 +2,6 @@
 
 var fs = require('fs');
 var path = require('path');
-var sys = require('sys')
 var exec = require('child_process').exec;
 
 var argv = require('minimist')(process.argv.slice(2));

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shalam",
-  "version": "1.0.8",
+  "version": "2.0.0",
   "description": "A tool for friendly CSS spriting",
   "bin": {
     "shalam": "./bin/shalam"
@@ -20,14 +20,14 @@
   "author": "Matt Basta <mattbasta@gmail.com>",
   "license": "Apache-2.0",
   "dependencies": {
-    "canvas": "1.1.6",
-    "crass": "^0.7.6",
-    "minimist": "^1.1.0",
-    "semver": "^5.0.1"
+    "canvas": "1.3.5",
+    "crass": "^0.7.8",
+    "minimist": "^1.2.0",
+    "semver": "^5.1.0"
   },
   "devDependencies": {
-    "mocha": "^1.21.4",
+    "mocha": "^2.3.4",
     "mockery": "^1.4.0",
-    "sinon": "^1.10.3"
+    "sinon": "^1.17.2"
   }
 }


### PR DESCRIPTION
- Update all of the deps
- Bump version to 2.0.0, since this is massively backwards-incompatible
- Remove unused `sys` reference, deprecated in new Node
- Travis file updated to add node 4/5

cc @tarrencev 

Fixes https://github.com/box/shalam/issues/1
