### PR TITLE
Sprite sheet compaction

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,4 +3,16 @@ node_js:
   - "0.10"
 script:
   - "npm test"
-before_install: sudo apt-get install libcairo2-dev libjpeg8-dev libpango1.0-dev libgif-dev build-essential g++
+addons:
+  apt:
+    sources:
+      - ubuntu-toolchain-r-test
+    packages:
+      - libcairo2-dev
+      - libjpeg8-dev
+      - libpango1.0-dev
+      - libgif-dev
+      - g++-4.8
+env:
+  - CXX=g++-4.8
+sudo: false

--- a/lib/layout.js
+++ b/lib/layout.js
@@ -15,8 +15,8 @@ var image = require('./image');
 var lcm = require('./lcm').lcm;
 
 
-var MIN_WIDTH = 514; // px
 var IMAGE_MARGIN = 2; // px
+var MIN_WIDTH = 512 + IMAGE_MARGIN; // px
 var IMAGE_SCALE_FACTOR = 2; // times
 
 
@@ -162,37 +162,44 @@ exports.performLayout = function performLayout(images) {
     var scaleFactorY;
 
     var layout = [];
+    var img;
+
+    var offsetX;
+    var offsetY;
     for (i = 0; i < images.length; i++) {
-        var img = images[i];
+        img = images[i];
 
         if (currentX + img.minSpritedSize.width > maxWidth) {
             currentX = 0;
             currentY = Math.ceil(nextY);
         }
 
+        offsetX = 0;
+        offsetY = 0;
+
         // Line up the sprite to the lowest common denominator (the nearest
         // pixel boundary).
         if (currentX) {
             scaleFactorX = getImageScaleFactor(img, 'width');
-            currentX += scaleFactorX - (currentX % scaleFactorX);
+            offsetX = scaleFactorX - (currentX % scaleFactorX);
         }
         if (currentY) {
             scaleFactorY = getImageScaleFactor(img, 'height');
-            currentY += scaleFactorY - (currentY % scaleFactorY);
+            offsetY = scaleFactorY - (currentY % scaleFactorY);
         }
 
         var result = {
             imageResource: img.imageResource,
             path: img.path,
-            x: currentX,
-            y: currentY,
+            x: currentX + offsetX,
+            y: currentY + offsetY,
             width: img.minSpritedSize.width,
             height: img.minSpritedSize.height,
         };
 
-        maxY = Math.max(maxY, currentY + result.height);
-        nextY = Math.max(nextY, currentY + result.height) + IMAGE_MARGIN;
-        currentX += result.width + IMAGE_MARGIN;
+        maxY = Math.max(maxY, currentY + result.height + offsetY);
+        nextY = Math.max(nextY, currentY + result.height + offsetY) + IMAGE_MARGIN;
+        currentX += result.width + IMAGE_MARGIN + offsetX;
         currentX = Math.ceil(currentX);
 
         layout.push(result);

--- a/lib/layout.js
+++ b/lib/layout.js
@@ -15,7 +15,7 @@ var image = require('./image');
 var lcm = require('./lcm').lcm;
 
 
-var MIN_WIDTH = 512; // px
+var MIN_WIDTH = 514; // px
 var IMAGE_MARGIN = 2; // px
 var IMAGE_SCALE_FACTOR = 2; // times
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shalam",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "description": "A tool for friendly CSS spriting",
   "bin": {
     "shalam": "./bin/shalam"

--- a/test/layout.js
+++ b/test/layout.js
@@ -103,7 +103,7 @@ describe('Layout', function() {
 
             var computedLayout = layout.performLayout(images);
             assert.equal(computedLayout.width, 700);
-            assert.equal(computedLayout.height, 26);
+            assert.equal(computedLayout.height, 24);
 
         });
 
@@ -116,7 +116,7 @@ describe('Layout', function() {
 
             var computedLayout = layout.performLayout(images);
             assert.equal(computedLayout.width, 700);
-            assert.equal(computedLayout.height, 26);
+            assert.equal(computedLayout.height, 24);
 
         });
 

--- a/test/layout.js
+++ b/test/layout.js
@@ -40,17 +40,17 @@ describe('Layout', function() {
 
         });
 
-        it('should make the layout a minumum of 256px wide', function() {
+        it('should make the layout a minumum of 514px wide', function() {
             var images = [
                 fakeImage(10, 10, 'first'),
             ];
 
             var computedLayout = layout.performLayout(images);
-            assert.equal(computedLayout.width, 512);
+            assert.equal(computedLayout.width, 514);
 
         });
 
-        it('should make the layout width equal to the widest element if it exceeds 256px', function() {
+        it('should make the layout width equal to the widest element if it exceeds 512px', function() {
             var images = [
                 fakeImage(700, 10, 'first'),
                 fakeImage(260, 200, 'second'),
@@ -189,7 +189,7 @@ describe('Layout', function() {
             ];
 
             var computedLayout = layout.performLayout(images);
-            assert.equal(computedLayout.width, 512);
+            assert.equal(computedLayout.width, 514);
             assert.equal(computedLayout.height, 256);
             assert.equal(img.warnings.length, 0);
 
@@ -206,7 +206,7 @@ describe('Layout', function() {
             ];
 
             var computedLayout = layout.performLayout(images);
-            assert.equal(computedLayout.width, 512);
+            assert.equal(computedLayout.width, 514);
             assert.equal(computedLayout.height, 256);
             assert.equal(img.warnings.length, 1);
 
@@ -235,13 +235,13 @@ describe('Layout', function() {
 
         });
 
-        it('should make the layout a minumum of 256px wide', function() {
+        it('should make the layout a minumum of 514px wide', function() {
             var images = [
                 fakeImage(10, 10, 'first'),
             ];
 
             var computedLayout = layout.performLayoutCompat(images);
-            assert.equal(computedLayout.width, 512);
+            assert.equal(computedLayout.width, 514);
 
         });
 


### PR DESCRIPTION
This does a couple things. First, it increases the minimum width by the image margin, allowing 256x icons to flow rather than stack. This will substantially cut down on file sizes for the main Box webapp sprite.

The second thing this does is fix an issue with LCM icon offsets.

![screen shot 2016-01-04 at 1 20 52 pm](https://cloud.githubusercontent.com/assets/279498/12100792/fee8591c-b2e5-11e5-9cb7-90e04e1890bb.png)

Notice how the icons in the above screenshot seem to be sliding off the edge of the sheet. There's a good explanation for why that happens in the commit description. The problem doesn't affect the final rendering of the page, only the file size (which should be somewhat smaller in the end).

Note that if this gets merged before #6, that's fine. If #6 is merged first, the version bump commit can be removed if `npm publish` is run _after_ this is merged (including this with 2.0.0).
